### PR TITLE
Update to support v2 agents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ group :development, :unit_tests do
 
   # puppet-lint and plugins
   gem 'puppet-lint',                                      '~> 2.2'
-  gem 'puppet-lint-absolute_classname-check',             '~> 0.2'
   gem 'puppet-lint-absolute_template_path',               '~> 1.0'
   gem 'puppet-lint-empty_string-check',                   '~> 0.2'
   gem 'puppet-lint-leading_zero-check',                   '~> 0.1'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -76,6 +76,7 @@ veeamagent::repo_path: '/etc/yum.repos.d/veeam.repo'
 veeamagent::repo_template: 'veeamagent/veeam-repo.epp'
 veeamagent::service_enable: true
 veeamagent::service_ensure: running
+veeamagent::service_manage: true
 veeamagent::service_name: 'veeamservice'
 veeamagent::snapshot_free_percent: 99
 veeamagent::snapshot_location:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,7 @@
 ---
+veeamagent::agent_version: 2
+veeamagent::backup_disks_mount:
+veeamagent::backup_disks_fs_mount:
 veeamagent::backup_job::block_size: 'KbBlockSize1024'
 veeamagent::backup_job::compression_type: 'Lz4'
 veeamagent::backup_job::config_dir: '/etc/veeam'
@@ -33,6 +36,8 @@ veeamagent::backup_job::vbrserver_port: 10002
 veeamagent::backup_repo::ensure: present
 veeamagent::backup_repo::location:
 veeamagent::bitlooker_enabled:
+veeamagent::bitlooker_exclude:
+veeamagent::bitlooker_timeout:
 veeamagent::cluster_align:
 veeamagent::config_ensure: present
 veeamagent::config_path: '/etc/veeam/veeam.ini'
@@ -49,16 +54,22 @@ veeamagent::gpgkey_ca_source: 'http://repository.veeam.com/keys/VeeamSoftwareRep
 veeamagent::gpgkey_ensure: present
 veeamagent::gpgkey_local: '/etc/pki/rpm-gpg/RPM-GPG-KEY-VeeamSoftwareRepo'
 veeamagent::gpgkey_source: 'http://repository.veeam.com/keys/RPM-GPG-KEY-VeeamSoftwareRepo'
+veeamagent::ignore_fuse_bug:
 veeamagent::inactivelvm_ignore:
 veeamagent::iorate_limit:
 veeamagent::job_retries:
+veeamagent::job_retry_interval:
 veeamagent::job_retryallerrors:
 veeamagent::log_debuglevel:
 veeamagent::log_dir:
+veeamagent::log_rotate_days:
 veeamagent::package_ensure: present
 veeamagent::package_manage: true
 veeamagent::package_name: ['veeam']
 veeamagent::prepost_timeout:
+veeamagent::reconnect_attempt_interval:
+veeamagent::reconnect_enabled:
+veeamagent::reconnect_overall_timeout:
 veeamagent::repo_baseurl: 'http://repository.veeam.com/backup/linux/agent/rpm/el/7/x86_64'
 veeamagent::repo_manage: true
 veeamagent::repo_path: '/etc/yum.repos.d/veeam.repo'
@@ -66,10 +77,14 @@ veeamagent::repo_template: 'veeamagent/veeam-repo.epp'
 veeamagent::service_enable: true
 veeamagent::service_ensure: running
 veeamagent::service_name: 'veeamservice'
+veeamagent::snapshot_free_percent: 99
 veeamagent::snapshot_location:
 veeamagent::snapshot_maxsize:
 veeamagent::snapshot_minsize:
 veeamagent::snapshot_type:
+veeamagent::snapshot_used_percent: 99
 veeamagent::socket_path:
 veeamagent::stretchsnapshot_portionsize:
+veeamagent::stretchsnapshot_storage_free_percent: 50
+veeamagent::temp_dir:
 veeamagent::veeamcmd_path: ['/usr/bin', '/usr/sbin']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,5 @@ class veeamagent::config inherits veeamagent {
     content => epp('veeamagent/veeam.ini.epp', {
       config_file_version => $config_file_version
     }),
-    notify  => Class['::veeamagent::service'],
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,15 @@
 # Handles the main configuration file.
 class veeamagent::config inherits veeamagent {
+  $config_file_version = $veeamagent::agent_version ? {
+    1 => 'v1.0.1.364',
+    2 => 'v2.0.0.400',
+  }
+
   file { $veeamagent::config_path:
     ensure  => $veeamagent::config_ensure,
-    content => epp('veeamagent/veeam.ini.epp'),
+    content => epp('veeamagent/veeam.ini.epp', {
+      config_file_version => $config_file_version
+    }),
     notify  => Class['::veeamagent::service'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@
 # @param repo_template String Path to a template for the Veeeam package repository. Default value: `'veeamagent/veeam-repo.epp'`.
 # @param service_enable Boolean Whether to enable the Veeam service. Default value: `true`.
 # @param service_ensure String Ensure value for the Veeam service. Default value: `running`.
+# @param service_manage Boolean Manage the service of the Veeam agent. Default value: true
 # @param service_name String Name of the Veeam service. Default value: varies by operating system.
 # @param snapshot_free_percent Integer[1,99] Free percent of storage. Used for calculate optimal snapshot data size and determinate snapshot data location, not for stretch snapshot. Default value: 99
 # @param snapshot_location [Optional[String]] Location folder for snapshot data, only for 'stretch' and 'common' snapshot. Default value: ''.
@@ -102,6 +103,7 @@ class veeamagent(
   String $repo_template,
   Boolean $service_enable,
   String $service_ensure,
+  Boolean $service_manage,
   String $service_name,
   Integer[1,99] $snapshot_free_percent,
   Optional[String] $snapshot_location,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,12 @@
 #
 # lint:ignore:80chars
 # lint:ignore:140chars
+# @param agent_version Integer[1,2] Set the major version of the agent. Default value: 2
+# @param backup_disks_fs_mount Optional[String[1]] Root folder path for mount file systems of backup disks
+# @param backup_disks_mount Optional[String[1]] Root folder path for mount backup disks
 # @param bitlooker_enabled [Optional[Boolean]] Allow to disable bitlooker. Default value: ''.
+# @param bitlooker_exclude Optional[Array[[String[1]]] An array of devices to exclude from BitLooker processing.
+# @param bitlooker_timeout Optional[Integer] BitLooker timeout per device in ms
 # @param cluster_align [Optional[Integer]] Backup cluster alignment logarithm. Default value: ''.
 # @param config_ensure String Ensure value for the main Veeam config file. Default value: `present`.
 # @param config_path String The path to where the main Veeam config files should be stored. Default value: varies by operating system.
@@ -19,32 +24,47 @@
 # @param gpgkey_ensure String Ensure value for the local Veeam GPG keys. Default value: varies by operating system.
 # @param gpgkey_local String Path to the local Veeam GPG Key. Default value: varies by operating system.
 # @param gpgkey_source String Path to the remote Veeam GPG Key. Default value: varies by operating system.
+# @param ignore_fuse_bug Optional[Boolean] Force FUSE mount on kernels 4.0.0-4.1.33 (for file level restore)
 # @param inactivelvm_ignore [Optional[Boolean]] Ignore inactive LVM logical volumes during backup. Default value: ''.
 # @param iorate_limit [Optional[Integer]] IO rate limit, from 0.01 to 1.0. Default value: ''.
 # @param job_retries [Optional[Integer]] New job default retries count. Default value: ''.
+# @param job_retry_interval Optional[Integer] Job retry delay interval in seconds
 # @param job_retryallerrors [Optional[Boolean]] Retry all errors, set to 'false' to enable retries only for 'snapshot overflow'. Default value: ''.
 # @param log_debuglevel [Optional[Integer]] Kernel log logging level. 7 - list all messages as an error, 4 or 0 - all messages as a warning, 2 - all message as a trace (use only if veeam works perfectly on your system). Default value: ''.
 # @param log_dir [Optional[String]] Logs path. Default value: ''.
+# @param log_rotate_days Optional[Integer] Logs rotation period in days
 # @param package_ensure String Ensure value for the Veeam package. Default value: `present`.
 # @param package_manage Boolean Whether to manage the Veeam package. Default value: `true`.
 # @param package_name [Array[String]] Name for the Veeam package. Default value: varies by operating system.
 # @param prepost_timeout [Optional[Integer]] Timeout for pre- and post-backup scripts. Default value: ''.
+# @param reconnect_attempt_interval Optional[Integer] Time to wait before each reconnect attempt in ms
+# @param reconnect_enabled Optional[Boolean] Enable reconnect
+# @param reconnect_overall_timeout Optional[Integer] Reconnect attempts timeout in ms
 # @param repo_manage Boolean Whether to manage the Veeam package repository. Default value: varies by operating system.
 # @param repo_path String Path to where package repositoy files are located. Default value: varies by operating system.
 # @param repo_template String Path to a template for the Veeeam package repository. Default value: `'veeamagent/veeam-repo.epp'`.
 # @param service_enable Boolean Whether to enable the Veeam service. Default value: `true`.
 # @param service_ensure String Ensure value for the Veeam service. Default value: `running`.
 # @param service_name String Name of the Veeam service. Default value: varies by operating system.
+# @param snapshot_free_percent Integer[1,99] Free percent of storage. Used for calculate optimal snapshot data size and determinate snapshot data location, not for stretch snapshot. Default value: 99
 # @param snapshot_location [Optional[String]] Location folder for snapshot data, only for 'stretch' and 'common' snapshot. Default value: ''.
 # @param snapshot_maxsize [Optional[Integer]] Maximum possible snapshot data size, not for stretch snapshot. Default value: ''.
 # @param snapshot_minsize [Optional[Integer]] Minimal possible snapshot data size, not for stretch snapshot. Default value: ''.
 # @param snapshot_type [Optional[String]] Snapshot data type, can be 'stretch' (default) or 'common'. Default value: ''.
+# @param snapshot_used_percent Integer[1,99] Used percent of storage. Used for calculate optimal snapshot data size and determinate snapshot data location, not for stretch snapshot. Default value: 99
 # @param socket_path [Optional[String]] Service socket. Default value: ''.
 # @param stretchsnapshot_portionsize [Optional[Integer]] Stretch snapshot data portion. Default value: ''.
+# @param stretchsnapshot_storage_free_percent Integer[1,99] Free percent of storage. Used for determinate snapshot data location. Only for stretch snapshot. Default value: 50
+# @param temp_dir Optional[String[1]] Temp directory path
 # lint:endignore
 # lint:endignore
 class veeamagent(
+  Integer[1,2] $agent_version,
+  Optional[String[1]] $backup_disks_fs_mount,
+  Optional[String[1]] $backup_disks_mount,
   Optional[Boolean] $bitlooker_enabled,
+  Optional[Array[String[1]]] $bitlooker_exclude,
+  Optional[Integer] $bitlooker_timeout,
   Optional[Integer] $cluster_align,
   String $config_ensure,
   String $config_path,
@@ -61,28 +81,38 @@ class veeamagent(
   String $gpgkey_ensure,
   String $gpgkey_local,
   String $gpgkey_source,
+  Optional[Boolean] $ignore_fuse_bug,
   Optional[Boolean] $inactivelvm_ignore,
   Optional[Integer] $iorate_limit,
   Optional[Integer] $job_retries,
+  Optional[Integer] $job_retry_interval,
   Optional[Boolean] $job_retryallerrors,
   Optional[Integer] $log_debuglevel,
   Optional[String] $log_dir,
+  Optional[Integer] $log_rotate_days,
   String $package_ensure,
   Boolean $package_manage,
   Array[String] $package_name,
   Optional[Integer] $prepost_timeout,
+  Optional[Integer] $reconnect_attempt_interval,
+  Optional[Boolean] $reconnect_enabled,
+  Optional[Integer] $reconnect_overall_timeout,
   Boolean $repo_manage,
   String $repo_path,
   String $repo_template,
   Boolean $service_enable,
   String $service_ensure,
   String $service_name,
+  Integer[1,99] $snapshot_free_percent,
   Optional[String] $snapshot_location,
   Optional[Integer] $snapshot_maxsize,
   Optional[Integer] $snapshot_minsize,
   Optional[String] $snapshot_type,
+  Integer[1,99] $snapshot_used_percent,
   Optional[String] $socket_path,
   Optional[Integer] $stretchsnapshot_portionsize,
+  Integer[1,99] $stretchsnapshot_storage_free_percent,
+  Optional[String] $temp_dir,
 ) {
 
   contain veeamagent::preinstall

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,13 +85,13 @@ class veeamagent(
   Optional[Integer] $stretchsnapshot_portionsize,
 ) {
 
-  contain ::veeamagent::preinstall
-  contain ::veeamagent::install
-  contain ::veeamagent::config
-  contain ::veeamagent::service
+  contain veeamagent::preinstall
+  contain veeamagent::install
+  contain veeamagent::config
+  contain veeamagent::service
 
-  Class['::veeamagent::preinstall']
-  -> Class['::veeamagent::install']
-  -> Class['::veeamagent::config']
-  ~> Class['::veeamagent::service']
+  Class['veeamagent::preinstall']
+  -> Class['veeamagent::install']
+  -> Class['veeamagent::config']
+  ~> Class['veeamagent::service']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,10 @@
 # Handles the service.
 class veeamagent::service inherits veeamagent {
-  service { $veeamagent::service_name:
-    ensure => $veeamagent::service_ensure,
-    enable => $veeamagent::service_enable,
+  if $veeamagent::service_manage {
+    service { $veeamagent::service_name:
+      ensure    => $veeamagent::service_ensure,
+      enable    => $veeamagent::service_enable,
+      subscribe => File[$veeamagent::config_path]
+    }
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,16 +1,81 @@
 require 'spec_helper'
 describe 'veeamagent::config' do
   on_supported_os.each do |os, facts|
-    context "on #{os} with custom settings" do
-      let(:pre_condition) { 'class {"::veeamagent": cluster_align => 5}' }
-      let(:facts) do
-        facts
+    let(:facts) do
+      facts
+    end
+
+    context "on #{os}" do
+      context 'with agent_version unspecified' do
+        let(:pre_condition) { 'class {"veeamagent": }' }
+
+        it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+                        .with_content(/veeam.ini, v2.0.0.400/)
+        }
       end
 
-      case facts[:osfamily]
-      when 'RedHat'
+      context 'with agent_version => 1' do
+        let(:pre_condition) { 'class {"veeamagent": agent_version => 1}' }
+
         it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
-        .with_content(/clusterAlign= 5/) }
+                        .with_content(/veeam.ini, v1.0.1.364/)
+        }
+
+        it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+                        .without_content(/exclude=/)
+        }
+      end
+
+      context 'with agent_version => 2' do
+        let(:pre_condition) { 'class {"veeamagent": agent_version => 2}' }
+
+        it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+                        .with_content(/veeam.ini, v2.0.0.400/)
+        }
+
+        it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+                        .with_content(/exclude=/)
+        }
+      end
+
+      context 'with agent_version => 3' do
+        let(:pre_condition) { 'class {"veeamagent": agent_version => 3}' }
+
+        it { is_expected.to compile.and_raise_error(/parameter 'agent_version' expects an Integer\[1, 2\] value/)
+        }
+      end
+
+      context "with custom settings" do
+        #stretchsnapshot_storage_free_percent
+
+
+        case facts[:os]['family']
+        when 'RedHat'
+          let(:pre_condition) { "
+            class { 'veeamagent':
+              cluster_align                        => 5,
+              bitlooker_exclude                    => [
+                '/dev/sda2',
+                '/dev/sdb4',
+              ],
+              stretchsnapshot_storage_free_percent => 75,
+            }"
+          }
+
+          it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+          .with_content(/clusterAlign= 5/) }
+
+          it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+          .with_content(/exclude= \/dev\/sda2, \/dev\/sdb4/) }
+
+          it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+          .with_content(/storageFreePercent= 75/) }
+        else
+          let(:pre_condition) { 'class {"veeamagent": stretchsnapshot_storage_free_percent => 75}' }
+
+          it { is_expected.to contain_file('/etc/veeam/veeam.ini') \
+          .with_content(/storageFreePercent= 75/) }
+        end
       end
     end
   end

--- a/spec/classes/preinstall_spec.rb
+++ b/spec/classes/preinstall_spec.rb
@@ -16,7 +16,7 @@ describe 'veeamagent::preinstall' do
     end
 
     context "on #{os} with repo_manage disabled" do
-      let(:pre_condition) { 'class {"::veeamagent": repo_manage => false}' }
+      let(:pre_condition) { 'class {"veeamagent": repo_manage => false}' }
 
        it { is_expected.not_to contain_file('/etc/yum.repos.d/veeam.repo') }
     end

--- a/templates/veeam.ini.epp
+++ b/templates/veeam.ini.epp
@@ -1,3 +1,5 @@
+<%- | String $config_file_version
+| -%>
 ##################################################################
 ###################################################################
 ####
@@ -6,7 +8,7 @@
 ####################################################################
 ####################################################################
 
-# veeam.ini, v1.0.1.364
+# veeam.ini, <%= $config_file_version %>
 # This is the veeamservice system-wide configuration file.
 # The strategy used for options in the default veeam.ini shipped with
 # Veeam Agent for Linux is to specify options with their default value where
@@ -39,12 +41,26 @@ priority= <%= $veeamagent::cpu_priority %>
 <% } -%>
 
 [bitlooker]
-# Allow to disable bitlooker
+# Enable BitLooker
 # enabled= true
 <% if $veeamagent::bitlooker_enabled {-%>
 enabled= <%= $veeamagent::bitlooker_enabled %>
 <% } -%>
+<% if $veeamagent::agent_version == 2 {-%>
 
+# Exclude the specified devices from BitLooker processing (e.g. /dev/sda1, /dev/sdb3)
+# exclude=
+<% if $veeamagent::bitlooker_exclude {-%>
+exclude= <%= $veeamagent::bitlooker_exclude.join(', ') %>
+<% } -%>
+
+# BitLooker timeout per device, ms
+# timeout= 900000
+<% if $veeamagent::bitlooker_timeout {-%>
+timeout= <%= $veeamagent::bitlooker_timeout %>
+<% } -%>
+
+<% } -%>
 [db]
 # Veeam database path
 # path= /var/lib/veeam/veeam_db.sqlite
@@ -66,10 +82,45 @@ schemeUpgradePath= <%= $veeamagent::db_schemeupgradepath %>
 
 
 [general]
+<% if $veeamagent::agent_version == 2 {-%>
+# Root folder path for mount file systems of backup disks
+# backupDisksFsMountFolder= /mnt/backup
+<% if $veeamagent::backup_disks_fs_mount {-%>
+backupDisksFsMountFolder= <%= $veeamagent::backup_disks_fs_mount %>
+<% } -%>
+
+# Root folder path for mount backup disks
+# backupDisksMountFolder= /mnt/backup
+<% if $veeamagent::backup_disks_mount {-%>
+backupDisksFsMountFolder= <%= $veeamagent::backup_disks_mount %>
+<% } -%>
+
+# Force FUSE mount on kernels 4.0.0-4.1.33 (for file level restore)
+# ignoreFuseBug= false
+<% if $veeamagent::ignore_fuse_bug {-%>
+ignoreFuseBug= <%= $veeamagent::ignore_fuse_bug %>
+<% } -%>
+
+<% } -%>
 # Logs path
 # logsFolder= /var/log/veeam
 <% if $veeamagent::log_dir {-%>
 logsFolder= <%= $veeamagent::log_dir %>
+<% } -%>
+<% if $veeamagent::agent_version == 2 {-%>
+
+# Logs rotation period, days
+# logsRotateDays= 14
+<% if $veeamagent::log_rotate_days {-%>
+logsRotateDays= <%= $veeamagent::log_rotate_days %>
+<% } -%>
+
+# Temp directory path
+# temporaryDirectory= /tmp/veeam
+<% if $veeamagent::temp_dir {-%>
+temporaryDirectory= <%= $veeamagent::temp_dir %>
+<% } -%>
+
 <% } -%>
 
 
@@ -79,6 +130,14 @@ logsFolder= <%= $veeamagent::log_dir %>
 <% if $veeamagent::job_retries {-%>
 retriesCount= <%= $veeamagent::job_retries %>
 <% } -%>
+<% if $veeamagent::agent_version == 2 {-%>
+
+# Job retry delay interval (seconds)
+# retriesInterval= 600
+<% if $veeamagent::job_retry_interval {-%>
+retriesInterval= <%= $veeamagent::job_retry_interval %>
+<% } -%>
+<% } -%>
 
 # Retry all errors, set to 'false' to enable retries only for 'snapshot overflow'
 # retryAllErrors= true
@@ -86,7 +145,27 @@ retriesCount= <%= $veeamagent::job_retries %>
 retryAllErrors= <%= $veeamagent::job_retryallerrors %>
 <% } -%>
 
+<% if $veeamagent::agent_version == 2 {-%>
+[reconnects]
+# Time to wait before each reconnect attempt, ms
+# attemptInterval= 5000
+<% if $veeamagent::reconnect_attempt_interval {-%>
+attemptInterval= <%= $veeamagent::reconnect_attempt_interval %>
+<% } -%>
 
+# Enable reconnect
+# enabled= true
+<% if $veeamagent::reconnect_enabled {-%>
+enabled= <%= $veeamagent::reconnect_enabled %>
+<% } -%>
+
+# Reconnect attempts timeout, ms
+# overallTimeout= 300000
+<% if $veeamagent::reconnect_overall_timeout {-%>
+overallTimeout= <%= $veeamagent::reconnect_overall_timeout %>
+<% } -%>
+
+<% } -%>
 [scripts]
 # Ignore freeze and thaw scripts result
 # ignoreFreezeThawFailures= false
@@ -109,13 +188,22 @@ timeoutPrePost= <%= $veeamagent::prepost_timeout %>
 
 [service]
 # Service socket
+<% if $veeamagent::agent_version == 1 {-%>
 # socket_path= /tmp/veeam/socket/veeam.sock
+<% } elsif $veeamagent::agent_version == 2 {-%>
+# socket_path= /var/tmp/veeam/socket/veeam.sock
+<% } -%>
 <% if $veeamagent::socket_path {-%>
 socket_path= <%= $veeamagent::socket_path %>
 <% } -%>
 
 
 [snapshot]
+<% if $veeamagent::agent_version == 2 {-%>
+# Free percent of storage. Used for calculate optimal snapshot data size and determinate snapshot data location, not for stretch snapshot
+freePercent= <%= $veeamagent::snapshot_free_percent %>
+
+<% } -%>
 # Percent of free space on block device can be used for snapshot data allocating
 # limitFreePercent= 50
 <% if $veeamagent::freepercent_limit {-%>
@@ -146,7 +234,13 @@ minSize= <%= $veeamagent::snapshot_minsize %>
 type= <%= $veeamagent::snapshot_type %>
 <% } -%>
 
+<% if $veeamagent::agent_version == 2 {-%>
+# Used percent of storage. Used for calculate optimal snapshot data size and determinate snapshot data location, not for stretch snapshot
+<% if $veeamagent::snapshot_used_percent {-%>
+usedPercent= <%= $veeamagent::snapshot_used_percent %>
+<% } -%>
 
+<% } -%>
 [stretchsnapshot]
 # Stretch snapshot data portion
 # portionSize= 1073741824
@@ -154,7 +248,13 @@ type= <%= $veeamagent::snapshot_type %>
 portionSize= <%= $veeamagent::stretchsnapshot_portionsize %>
 <% } -%>
 
+<% if $veeamagent::agent_version == 2 {-%>
+# Free percent of storage. Used for determinate snapshot data location. Only for stretch snapshot
+<% if $veeamagent::stretchsnapshot_storage_free_percent {-%>
+storageFreePercent= <%= $veeamagent::stretchsnapshot_storage_free_percent %>
+<% } -%>
 
+<% } -%>
 [veeamsnap]
 # Kernel log logging level. 7 - list all messages as an error, 4 or 0 - all messages as a warning, 2 - all message as a trace (use only if veeam works perfectly on your system)
 # debuglogging= 0


### PR DESCRIPTION
As part of updating this module to support v2 agents the default version has also been set to 2. Anyone still using the v1 agent will need to explicitly change the agent_version parameter to 1.